### PR TITLE
Fix: Use Python agent for Python services instead of flex agent

### DIFF
--- a/contrast-cargo-cats/templates/docservice.yaml
+++ b/contrast-cargo-cats/templates/docservice.yaml
@@ -6,7 +6,7 @@ metadata:
   name: '{{.Release.Name}}-{{ .Values.docservice.name }}'
   namespace: {{ .Release.Namespace }}
   labels:
-    contrast-agent: flex
+    contrast-agent: python
 spec:
   selector:
     matchLabels:

--- a/contrast-cargo-cats/templates/webhookservice.yaml
+++ b/contrast-cargo-cats/templates/webhookservice.yaml
@@ -4,7 +4,7 @@ metadata:
   name: '{{.Release.Name}}-{{ .Values.webhookservice.name }}'
   namespace: {{ .Release.Namespace }}
   labels:
-    contrast-agent: flex
+    contrast-agent: python
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The flex agent did not properly instrument Python applications, resulting in Python services (webhookservice and docservice) not appearing in the Contrast UI.

Changes:
- webhookservice.yaml: Changed contrast-agent label from 'flex' to 'python'
- docservice.yaml: Changed contrast-agent label from 'flex' to 'python'

With this fix, both Python services now:
- Generate agent logs in /contrast/data/logs/
- Successfully report to Contrast TeamServer
- Appear in the Contrast UI with proper telemetry

Tested with:
- Python 3.11 (docservice)
- Python 3.12 (webhookservice)
- Contrast Python agent v11.2.0